### PR TITLE
chore(version): adjust to zeebe 0.3.0 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,8 @@
 	</parent>
 
 	<properties>
-		<version.zeebe>${project.version}</version.zeebe>
+		<version.zeebe>0.3.0-SNAPSHOT</version.zeebe>
+		<version.zb-bpmn-model>0.1.0-SNAPSHOT</version.zb-bpmn-model>
 		<version.dmn>7.8.0-SNAPSHOT</version.dmn>
 		<version.feel>1.2.0-SNAPSHOT</version.feel>
 	</properties>
@@ -58,7 +59,7 @@
 		<dependency>
 			<groupId>io.zeebe</groupId>
 			<artifactId>zb-bpmn-model</artifactId>
-			<version>${version.zeebe}</version>
+			<version>${version.zb-bpmn-model}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/src/main/java/io/zeebe/dmn/DmnApplication.java
+++ b/src/main/java/io/zeebe/dmn/DmnApplication.java
@@ -46,7 +46,6 @@ public class DmnApplication
     {
         client = ZeebeClient.create(clientProperties);
 
-        client.connect();
         LOG.debug("Connected.");
 
         taskWorker = buildTaskWorker(client);

--- a/src/test/java/io/zeebe/WorkflowTest.java
+++ b/src/test/java/io/zeebe/WorkflowTest.java
@@ -18,6 +18,7 @@ package io.zeebe;
 import static io.zeebe.fixtures.ZeebeTestRule.DEFAULT_TOPIC;
 
 import io.zeebe.client.ZeebeClient;
+import io.zeebe.client.event.ResourceType;
 import io.zeebe.client.event.WorkflowInstanceEvent;
 import io.zeebe.dmn.DmnApplication;
 import io.zeebe.fixtures.ZeebeTestRule;
@@ -55,7 +56,7 @@ public class WorkflowTest
         final String workflowAsString = Bpmn.convertToString(workflowDefinition);
 
         client.workflows().deploy(DEFAULT_TOPIC)
-                .resourceStringUtf8(workflowAsString)
+                .resourceStringUtf8(workflowAsString, ResourceType.BPMN_XML)
                 .execute();
     }
 

--- a/src/test/java/io/zeebe/fixtures/ClientRule.java
+++ b/src/test/java/io/zeebe/fixtures/ClientRule.java
@@ -45,7 +45,6 @@ public class ClientRule extends ExternalResource
     protected void before() throws Throwable
     {
         client = ZeebeClient.create(properties);
-        client.connect();
     }
 
     @Override


### PR DESCRIPTION
- decouple zeebe and zb-bpmn-model version from project version
- remove client.connect()
- provide ResourceType parameter to deploy method