### PR TITLE
Create default topic during test setup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
 
 	<properties>
 		<version.zeebe>0.4.0</version.zeebe>
-		<version.dmn>7.8.0-SNAPSHOT</version.dmn>
-		<version.feel>1.2.0-SNAPSHOT</version.feel>
+		<version.dmn>7.8.0-alpha5</version.dmn>
+		<version.feel>1.3.0</version.feel>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,7 @@
 	</parent>
 
 	<properties>
-		<version.zeebe>0.3.0</version.zeebe>
-		<version.zb-bpmn-model>0.1.0</version.zb-bpmn-model>
+		<version.zeebe>0.4.0</version.zeebe>
 		<version.dmn>7.8.0-SNAPSHOT</version.dmn>
 		<version.feel>1.2.0-SNAPSHOT</version.feel>
 	</properties>
@@ -59,7 +58,7 @@
 		<dependency>
 			<groupId>io.zeebe</groupId>
 			<artifactId>zb-bpmn-model</artifactId>
-			<version>${version.zb-bpmn-model}</version>
+			<version>${version.zeebe}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/src/test/java/io/zeebe/WorkflowTest.java
+++ b/src/test/java/io/zeebe/WorkflowTest.java
@@ -15,7 +15,7 @@
  */
 package io.zeebe;
 
-import static io.zeebe.fixtures.ZeebeTestRule.DEFAULT_TOPIC;
+import static io.zeebe.fixtures.ClientRule.DEFAULT_TOPIC;
 
 import io.zeebe.client.ZeebeClient;
 import io.zeebe.client.event.ResourceType;

--- a/src/test/java/io/zeebe/fixtures/ZeebeTestRule.java
+++ b/src/test/java/io/zeebe/fixtures/ZeebeTestRule.java
@@ -33,8 +33,6 @@ import org.junit.rules.ExternalResource;
 
 public class ZeebeTestRule extends ExternalResource
 {
-    public static final String DEFAULT_TOPIC = "default-topic";
-
     private EmbeddedBrokerRule brokerRule;
     private ClientRule clientRule;
     private TopicEventRecorder topicEventRecorder;
@@ -47,9 +45,9 @@ public class ZeebeTestRule extends ExternalResource
     public ZeebeTestRule(Supplier<InputStream> configSupplier, Supplier<Properties> propertiesProvider)
     {
         brokerRule = new EmbeddedBrokerRule(configSupplier);
-        clientRule = new ClientRule(propertiesProvider);
+        clientRule = new ClientRule(propertiesProvider, true);
 
-        topicEventRecorder = new TopicEventRecorder(clientRule, DEFAULT_TOPIC);
+        topicEventRecorder = new TopicEventRecorder(clientRule, clientRule.getDefaultTopic());
     }
 
     public ZeebeClient getClient()
@@ -128,6 +126,16 @@ public class ZeebeTestRule extends ExternalResource
         {
             // ignore
         }
+    }
+
+    public String getDefaultTopic()
+    {
+        return clientRule.getDefaultTopic();
+    }
+
+    public int getDefaultPartition()
+    {
+        return clientRule.getDefaultPartition();
     }
 
 }


### PR DESCRIPTION
Since Zeebe 0.4.0 no default topic is created on broker startup, therefore the test case has to create the topic it uses.

**Note**: this change requires the release of Zeebe 0.4.0 